### PR TITLE
VSIX now uses FDD CLI. Updates to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 Sitefinity VSIX is a Visual Studio extension that allows you to create Sitefinity CMS related resources. This way you can easily scaffold Sitefinity CMS projects. The tool is focused on facilitating the development of MVC widgets and templates.
 
 ## Installation
-**PREREQUISITES**: You must be using Microsoft Visual Studio 2015 or 2017.
+Supported Visual Studio Versions: 2015, 2017 and 2019.
+
+Note: For Visual Studio 2015 and 2017 (up to Update 15.3) you first need to install [.NET Core](https://www.microsoft.com/net/download/windows) before using the extension.
 
 You can download the extension from Visual Studio Marketplace >> [Sitefinity VSIX](https://marketplace.visualstudio.com/items?itemName=vs-publisher-443.Sitefinity-VSIX).
 

--- a/Sitefinity-VSIX/Commands/AboutCommand.cs
+++ b/Sitefinity-VSIX/Commands/AboutCommand.cs
@@ -14,15 +14,14 @@ namespace Sitefinity_VSIX.Commands
 
         public AboutCommand(EventHandler handler, CommandID command, string cliPath) : base(handler, command)
         {
-            var dllPath = cliPath.Replace(".exe", ".dll");
-            if (!File.Exists(dllPath))
+            if (!File.Exists(cliPath))
             {
                 throw new FileNotFoundException();
             }
 
             this.vsixVersion = Assembly.GetExecutingAssembly().GetName().Version;
 
-            var versionInfo = FileVersionInfo.GetVersionInfo(dllPath).FileVersion;
+            var versionInfo = FileVersionInfo.GetVersionInfo(cliPath).FileVersion;
 
             if (!Version.TryParse(versionInfo, out this.cliVersion))
             {

--- a/Sitefinity-VSIX/Shared/CliDownloader.cs
+++ b/Sitefinity-VSIX/Shared/CliDownloader.cs
@@ -13,7 +13,7 @@ namespace Sitefinity_VSIX.Shared
 {
     internal class CliDownloader
     {
-        public static void SetUp(string exePath)
+        public static void SetUp(string cliPath)
         {
             // Get current version
             var currentVersion = Assembly.GetExecutingAssembly().GetName().Version;
@@ -28,21 +28,20 @@ namespace Sitefinity_VSIX.Shared
                 var latestReleaseVersion = ParseReleaseMajorVersion(latestRelease.Version);
 
                 // check if cli is already downloaded or its current version is lower than the latest release version
-                if (File.Exists(exePath))
+                if (File.Exists(cliPath))
                 {
                     // get cli version
-                    var dllPath = Path.ChangeExtension(exePath, ".dll");
-                    var versionInfo = FileVersionInfo.GetVersionInfo(dllPath);
+                    var versionInfo = FileVersionInfo.GetVersionInfo(cliPath);
                     Version cliVersion = Version.Parse(versionInfo.FileVersion);
 
                     if (cliVersion.CompareTo(latestReleaseVersion) < 0)
                     {
-                        HandleCliDownloadAndExtraction(latestRelease, exePath);
+                        HandleCliDownloadAndExtraction(latestRelease, cliPath);
                     }
                 }
                 else
                 {
-                    HandleCliDownloadAndExtraction(latestRelease, exePath);
+                    HandleCliDownloadAndExtraction(latestRelease, cliPath);
                 }
             }
         }
@@ -70,12 +69,12 @@ namespace Sitefinity_VSIX.Shared
             }
         }
 
-        private static void HandleCliDownloadAndExtraction(Release release, string exePath)
+        private static void HandleCliDownloadAndExtraction(Release release, string cliPath)
         {     
             var asset = release.Assets.Where(x => x.Name == Constants.WindowsReleaseName).FirstOrDefault();
             if (asset != null)
             {
-                var cliDirectoryName = Path.GetDirectoryName(exePath);
+                var cliDirectoryName = Path.GetDirectoryName(cliPath);
 
                 if (Directory.Exists(cliDirectoryName))
                 {

--- a/Sitefinity-VSIX/Shared/Constants.cs
+++ b/Sitefinity-VSIX/Shared/Constants.cs
@@ -2,8 +2,10 @@
 {
     internal class Constants
     {
+        public const string DotNetCoreProcessName = "dotnet";
+
         public const string CLIFolderName = "cli";
-        public const string CLIName = "sf.exe";
+        public const string CLIName = "sf.dll";
         public const string ConfigFileName = "config.json";
 
         public const string ResourcePackagesFolderName = "ResourcePackages";

--- a/Sitefinity-VSIX/source.extension.vsixmanifest
+++ b/Sitefinity-VSIX/source.extension.vsixmanifest
@@ -1,22 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="Sitefinity_VSIX.a50d7171-cff9-4008-8253-ebe88a67e426" Version="1.0.0.1" Language="en-US" Publisher="Progress" />
-        <DisplayName>Sitefinity VSIX</DisplayName>
-        <Description xml:space="preserve">Visual studio extension for creating a Sitefinity related files.</Description>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
-        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6.1,)" />
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+	<Metadata>
+		<Identity Id="Sitefinity_VSIX.a50d7171-cff9-4008-8253-ebe88a67e426" Version="1.0.0.2" Language="en-US" Publisher="Progress" />
+		<DisplayName>Sitefinity VSIX</DisplayName>
+		<Description xml:space="preserve">Visual studio extension for creating a Sitefinity related files.</Description>
+	</Metadata>
+	<Installation>
+		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
+		<InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+		<InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+	</Installation>
+	<Dependencies>
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6.1,)" />
+	</Dependencies>
+	<Prerequisites>
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.NetCore.ComponentGroup.Web.2.1" Version="[15.0,)" DisplayName=".NET Core 2.1 development tools" />
+	</Prerequisites>
+	<Assets>
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+	</Assets>
 </PackageManifest>

--- a/Sitefinity-VSIX/vNextPackage.cs
+++ b/Sitefinity-VSIX/vNextPackage.cs
@@ -29,23 +29,23 @@ namespace Sitefinity_VSIX
                     if (commandService != null)
                     {
                         var extentionPath = Path.GetDirectoryName(this.GetType().Assembly.Location);
-                        var exePath = Path.Combine(extentionPath, Constants.CLIFolderName, Constants.CLIName);
+                        var dllPath = Path.Combine(extentionPath, Constants.CLIFolderName, Constants.CLIName);
                         var configPath = Path.Combine(extentionPath, Constants.CLIFolderName, Constants.ConfigFileName);
 
-                        CliDownloader.SetUp(exePath);
+                        CliDownloader.SetUp(dllPath);
 
                         var fileInfo = new FileInfo(configPath);
 
                         if (!fileInfo.Exists)
                         {
+                            var args = string.Format("{0} config", Constants.CLIName);
                             var process = new Process();
-                            process.StartInfo.FileName = fileInfo.Name;
                             process.StartInfo.WorkingDirectory = fileInfo.DirectoryName;
                             process.StartInfo.RedirectStandardOutput = true;
                             process.StartInfo.UseShellExecute = false;
                             process.StartInfo.CreateNoWindow = true;
-                            process.StartInfo.FileName = exePath;
-                            process.StartInfo.Arguments = "config";
+                            process.StartInfo.FileName = Constants.DotNetCoreProcessName;
+                            process.StartInfo.Arguments = args;
                             process.Start();
                             process.WaitForExit();
                         }
@@ -56,7 +56,7 @@ namespace Sitefinity_VSIX
                         commandService.AddCommand(dynamicCommand);
 
                         var aboutCommandRootId = new CommandID(PackageGuids.guidPackageCommandSet, PackageIds.AboutCommandId);
-                        var aboutCommand = new AboutCommand(OnInvokeAboutCommand, aboutCommandRootId, exePath);
+                        var aboutCommand = new AboutCommand(OnInvokeAboutCommand, aboutCommandRootId, dllPath);
                         commandService.AddCommand(aboutCommand);
                     }
                 });
@@ -108,10 +108,10 @@ namespace Sitefinity_VSIX
                     }
                 }
 
-                args = String.Format("{0} -r \"{1}\"", args, currentProjectPath);
+                args = String.Format("{0} {1} -r \"{2}\"", Constants.CLIName, args, currentProjectPath);
 
                 var process = new Process();
-                process.StartInfo.FileName = fileInfo.Name;
+                process.StartInfo.FileName = Constants.DotNetCoreProcessName;
                 process.StartInfo.WorkingDirectory = fileInfo.DirectoryName;
                 process.StartInfo.Arguments = args;
                 process.Start();


### PR DESCRIPTION
VSIX now uses framework-dependent Sitefinity CLI for optimized package size (from 30 mb to 3mb) and better first experience interaction. Updated supported VS versions in readme.